### PR TITLE
なぞの空白でビルでできない問題解決

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -11,7 +11,7 @@ APPL_DIRS += $(sort $(dir $(APP_CPP_PATHS)))
 APPL_CXXFLAGS += -std=gnu++17 -O2
 
 # 自作ヘッダのパス
-INCLUDES += \ 
+INCLUDES += \
     -I$(mkfile_path)include \
     -I$(mkfile_path)src \
     -I$(mkfile_path)external/drivers \


### PR DESCRIPTION
変な空白があって`make build`ができなかったので修正
実際に出たエラー

```
root@244f01d872e1:/opt/spike-rt/sdk/workspace/kait-etrobocon2026# QUIET=0 make build
building...
make[1]: Entering directory '/opt/spike-rt/sdk/workspace'
/opt/spike-rt/sdk/workspace/kait-etrobocon2026/Makefile.inc:15: *** missing separator.  Stop.
make[1]: Leaving directory '/opt/spike-rt/sdk/workspace'
make: *** [Makefile:31: build] Error 2
```